### PR TITLE
Add screenshot sections to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,6 +16,20 @@ HootVoice はマイク音声を録音し、Whisper でリアルタイムに文�
 - 効果音（開始／処理中／完了、音量調整可能）
  - 完全ローカル: 端末内で完結（クラウド不要・API費用なし）
 
+## スクリーンショット
+
+<p align="center">
+  <a href="docs/img/logs.png"><img src="docs/img/logs.png" width="260" alt="Transcription log" /></a>
+  <a href="docs/img/settings.png"><img src="docs/img/settings.png" width="260" alt="Settings overview" /></a>
+  <a href="docs/img/devices.png"><img src="docs/img/devices.png" width="260" alt="Audio devices" /></a>
+</p>
+
+<p align="center">
+  <a href="docs/img/dictionary.png"><img src="docs/img/dictionary.png" width="260" alt="User dictionary" /></a>
+  <a href="docs/img/model.png"><img src="docs/img/model.png" width="260" alt="Model selection" /></a>
+  <a href="docs/img/floating.png"><img src="docs/img/floating.png" width="260" alt="Floating window" /></a>
+</p>
+
 ## 要件
 
 - Rust 1.70+、C/C++ ビルド環境
@@ -63,10 +77,6 @@ HootVoice は音声認識を端末上（ローカル）で実行します。音�
 - 速度: ネットワーク遅延の影響を受けず、CPU/GPU とモデルサイズに応じて高速に動作。
 - コスト: API の従量課金は不要（無料）。
 - ネットワーク利用: 初回のモデルダウンロード時のみ通信します。オフライン利用は、事前に `models/` に ggml モデルを配置してください。
-
-### Whisper モデルのライセンス
-
-HootVoice は利用時に Whisper の ggml モデルをダウンロードします。Whisper（および利用している ggml 変換版）は OpenAI によって MIT License で提供されています。再配布を行う場合などは、[Whisper リポジトリ](https://github.com/openai/whisper#license) に記載された条件をご確認ください。
 
 ## 実行
 
@@ -155,15 +165,17 @@ Waybar のスタイル例（`~/.config/waybar/style.css`）:
 - 自動ペースト（Linux）: Wayland は `wtype`、X11 は `xdotool` を導入。未導入時はコピーのみになります。
 - マイクが見えない: `aplay -l` / `arecord -l` で確認。オーディオサーバの稼働を確認。
 
-## サードパーティライセンス
-
-アプリには `assets/THIRD_PARTY_LICENSES.md`（`cargo-about` で生成）が同梱され、設定画面から参照できます。
-
 ## ライセンス
 
 MIT
 
-HootVoice がダウンロードする Whisper モデル（ggml 版を含む）は OpenAI による MIT License の提供物です。モデルを再配布する際は、[Whisper リポジトリのライセンス](https://github.com/openai/whisper#license) を必ず確認してください。
+## サードパーティライセンス
+
+アプリには `assets/THIRD_PARTY_LICENSES.md`（`cargo-about` で生成）が同梱され、設定画面から参照できます。
+
+## Whisper モデルのライセンス
+
+HootVoice は利用時に Whisper の ggml モデルをダウンロードします。Whisper（および利用している ggml 変換版）は OpenAI によって MIT License で提供されています。再配布を行う場合などは、[Whisper リポジトリ](https://github.com/openai/whisper#license) に記載された条件をご確認ください。
 
 ## 貢献
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,19 @@ HootVoice runs entirely on your device. Audio is not uploaded to any server.
 - Performance: no network latency; speed depends on CPU/GPU and chosen model.
 - Cost: no API usage fees. Only the first-time model download needs network; you can pre-seed `models/` for offline use.
 
-### Whisper model licensing
+## Screenshots
 
-HootVoice downloads Whisper models on demand. Whisper (and the ggml conversions it uses) are released under the MIT License by OpenAI. See the [Whisper repository](https://github.com/openai/whisper#license) for full terms before redistributing models with your own builds.
+<p align="center">
+  <a href="docs/img/logs.png"><img src="docs/img/logs.png" width="260" alt="Transcription log" /></a>
+  <a href="docs/img/settings.png"><img src="docs/img/settings.png" width="260" alt="Settings overview" /></a>
+  <a href="docs/img/devices.png"><img src="docs/img/devices.png" width="260" alt="Audio devices" /></a>
+</p>
+
+<p align="center">
+  <a href="docs/img/dictionary.png"><img src="docs/img/dictionary.png" width="260" alt="User dictionary" /></a>
+  <a href="docs/img/model.png"><img src="docs/img/model.png" width="260" alt="Model selection" /></a>
+  <a href="docs/img/floating.png"><img src="docs/img/floating.png" width="260" alt="Floating window" /></a>
+</p>
 
 ## Requirements
 
@@ -166,15 +176,19 @@ Notes:
 - Auto‑paste on Linux: install `wtype` on Wayland or `xdotool` on X11. If not available, the app falls back to copy‑only.
 - No microphone devices: check ALSA devices (`aplay -l`, `arecord -l`) and audio server.
 
-## Third‑party licenses
-
-The app bundles `assets/THIRD_PARTY_LICENSES.md` generated via `cargo-about` for in‑app viewing (Settings → General).
-
 ## License
 
 MIT
 
 Runtime Whisper models downloaded through HootVoice are provided by OpenAI under the MIT License; review the upstream [Whisper license](https://github.com/openai/whisper#license) before redistributing bundled models.
+
+## Third‑party licenses
+
+The app bundles `assets/THIRD_PARTY_LICENSES.md` generated via `cargo-about` for in‑app viewing (Settings → General).
+
+## Whisper model licensing
+
+HootVoice downloads Whisper models on demand. Whisper (and the ggml conversions it uses) are released under the MIT License by OpenAI. See the [Whisper repository](https://github.com/openai/whisper#license) for full terms before redistributing models with your own builds.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- add screenshot galleries to the English and Japanese READMEs
- relocate licensing sections to keep the Whisper notice visible after the new screenshots

## Testing
- not run (docs only)
