### PR TITLE
Remove similar-based diff logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,7 +2073,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "signal-hook",
- "similar",
  "sys-locale",
  "toml",
  "tracing",
@@ -4082,12 +4081,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ serde_json = "1.0"
 toml = "0.8"
 serde_yaml = "0.9"
 image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }
-similar = "2.6"
 
 # GUI
 egui = "0.32"


### PR DESCRIPTION
## Summary
- remove the similar crate dependency
- simplify post-process logging to only report whether LLM output matches Whisper text

## Testing
- cargo fmt --all
- cargo build
