### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.2.0
+
+The owl picked up a few new tricks. 🦉✨ Whisper transcripts can now take a quick detour through your favorite local LLM to get cleaned up, summarized, or remixed before they land in your app.
+
+- Added an opt-in LLM post-processing engine with a local-only HTTP client, presets for formatting or summarizing, and full custom prompt support.
+- Expanded Settings with a dedicated LLM tab: configure base URL/model, control auto-paste behavior, and inspect recent history saved to disk.
+- Published a new `llm-postprocess` guide and refreshed the manual so you can get up and running with Ollama, LM Studio, and friends.
+- Trimmed unused diff logging code to keep builds leaner.
+
 ## v0.1.0
 
 HootVoice takes the stage for the very first time — cue the confetti! 🎉

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,7 +2073,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "signal-hook",
- "similar",
  "sys-locale",
  "toml",
  "tracing",
@@ -4082,12 +4081,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "hootvoice"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hootvoice"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["HootVoice Team"]
 description = "HootVoice — High‑accuracy voice input (Whisper)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ serde_json = "1.0"
 toml = "0.8"
 serde_yaml = "0.9"
 image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }
-similar = "2.6"
 
 # GUI
 egui = "0.32"

--- a/assets/THIRD_PARTY_LICENSES.md
+++ b/assets/THIRD_PARTY_LICENSES.md
@@ -11085,7 +11085,7 @@ SOFTWARE.
 
 Used by:
 
-- hootvoice 0.1.0 (https://github.com/agata/hootvoice)
+- hootvoice 0.2.0 (https://github.com/agata/hootvoice)
 
 License text:
 
@@ -12690,5 +12690,4 @@ the following restrictions:
 ```
 
 ---
-
 


### PR DESCRIPTION
## Summary
- bump crate metadata to 0.2.0 and regenerate Cargo.lock
- document the 0.2.0 release in CHANGELOG
- refresh third party license manifest with the new version number

## Testing
- cargo build